### PR TITLE
IMPP: percent-encode handles in URI

### DIFF
--- a/src/main/java/ezvcard/io/scribe/ImppScribe.java
+++ b/src/main/java/ezvcard/io/scribe/ImppScribe.java
@@ -127,7 +127,7 @@ public class ImppScribe extends VCardPropertyScribe<Impp> {
 
 	private String write(Impp property) {
 		URI uri = property.getUri();
-		return (uri == null) ? "" : uri.toString();
+		return (uri == null) ? "" : uri.toASCIIString();
 	}
 
 	private Impp parse(String value) {
@@ -220,7 +220,7 @@ public class ImppScribe extends VCardPropertyScribe<Impp> {
 				return format.buildLink(handle);
 			}
 		}
-		return uri.toString();
+		return uri.toASCIIString();
 	}
 
 	private static class HtmlLinkFormat {


### PR DESCRIPTION
When users are allowed to enter IMPP schemes and handles, they (of course) enter invalid characters. I think the ez-vcard-calling application is responsible for filtering and purifying these values (handle=URI scheme and name=URI scheme specific part).

However, special characters are valid in the scheme specific part. Think of a messenger called "special", with handle "öffentlich" (German word) or a handle containing other special characters (Unicode smileys, etc).

Currently, ez-vcard uses `new URI(scheme, schemeSpecificPart, null)`, which is capable of handling special characters in `schemeSpecificPart`. However, then `ImppScribe` calls `toString()` which generates `special:öffentlich`. According to RFC 6350, a VCard URI is defined by RFC 3986, which defines an URI as (I only quote the relevant lines):

```
URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]

      hier-part   = "//" authority path-abempty
                  / path-absolute
                  / path-rootless
                  / path-empty
      path          = path-abempty    ; begins with "/" or is empty
                    / path-absolute   ; begins with "/" but not "//"
                    / path-noscheme   ; begins with a non-colon segment
                    / path-rootless   ; begins with a segment
                    / path-empty      ; zero characters
      path-rootless = segment-nz *( "/" segment )
      segment       = *pchar
      segment-nz    = 1*pchar
      pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
```

So, unencoded values must not be in the URI (at least this is my interpretation).

Therefore I suggest to change `toString()` to `toASCIIString()´. In this case, special characters are encoded in UTF-8, which is basically ambiguous because nobody says that special characters have to be encoded as UTF-8. However, if unambiguity is required, the calling application could still filter special characters.

PS: This is a real world problem. Android lets users enter arbitrary IMPP handles and names, and DAVdroid tries to put them into a VCard (and vice versa). And you can't image the values users try to enter… (handle: "forum xxx user", name with special chars)

Please don't call me crazy. ;)