### PR TITLE
FoldedLineWriter: fix folding inside surrogate pairs

### DIFF
--- a/src/main/java/ezvcard/io/text/FoldedLineWriter.java
+++ b/src/main/java/ezvcard/io/text/FoldedLineWriter.java
@@ -232,6 +232,16 @@ public class FoldedLineWriter extends Writer {
 					}
 				}
 
+				// if last char is the low (second) char in a surrogate pair,
+				// don't split the pair across two lines.
+				if (Character.isLowSurrogate(c)) {
+					i++;
+					if (i >= end - 1) {
+						// surrogate pair finishes the array, leave
+						break;
+					}
+				}
+
 				writer.write(cbuf, start, i - start);
 				if (quotedPrintable) {
 					writer.write('=');

--- a/src/test/java/ezvcard/io/text/FoldedLineWriterTest.java
+++ b/src/test/java/ezvcard/io/text/FoldedLineWriterTest.java
@@ -154,6 +154,20 @@ public class FoldedLineWriterTest {
 	}
 
 	@Test
+	public void write_surrogate_pair_end() throws Exception {
+		StringWriter sw = new StringWriter();
+		FoldedLineWriter writer = new FoldedLineWriter(sw);
+		writer.setLineLength(5);
+
+		String str = "test\uD83D\uDCF0"; // should not be split
+		writer.write(str, false, Charset.forName("UTF-8"));
+		writer.close();
+		String actual = sw.toString();
+
+		assertEquals("test\uD83D\uDCF0", actual);
+	}
+
+	@Test
 	public void write_different_newlines() throws Exception {
 		StringWriter sw = new StringWriter();
 		FoldedLineWriter writer = new FoldedLineWriter(sw);

--- a/src/test/java/ezvcard/io/text/FoldedLineWriterTest.java
+++ b/src/test/java/ezvcard/io/text/FoldedLineWriterTest.java
@@ -140,6 +140,20 @@ public class FoldedLineWriterTest {
 	}
 
 	@Test
+	public void write_surrogate_pair() throws Exception {
+		StringWriter sw = new StringWriter();
+		FoldedLineWriter writer = new FoldedLineWriter(sw);
+		writer.setLineLength(5);
+
+		String str = "test\uD83D\uDCF0test"; // should not be split
+		writer.write(str, false, Charset.forName("UTF-8"));
+		writer.close();
+		String actual = sw.toString();
+
+		assertEquals("test\uD83D\uDCF0\r\n test", actual);
+	}
+
+	@Test
 	public void write_different_newlines() throws Exception {
 		StringWriter sw = new StringWriter();
 		FoldedLineWriter writer = new FoldedLineWriter(sw);


### PR DESCRIPTION
Tricky bug, since it only happens if you happen to have a surrogate pair right at the line boundary.