### PR TITLE
Implement equals/hashCode/toString on all VCardProperties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</scm>
 
 	<properties>
-		<java.version>1.5</java.version>
+		<java.version>1.6</java.version>
 	</properties>
 
 	<dependencies>
@@ -159,7 +159,7 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.3</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<source>${java.version}</source>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.16.6</version>
+			<scope>provided</scope>
+		</dependency>
 		<!--
 		Source code of commons-codec has been included in the project to improve Android compatibility.
 		See: https://groups.google.com/forum/?fromgroups=#!topic/ez-vcard-discuss/w2TK7yetwr8

--- a/src/main/java/ezvcard/ValidationWarnings.java
+++ b/src/main/java/ezvcard/ValidationWarnings.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.IdentityHashMap;
 
 import ezvcard.property.VCardProperty;
 import ezvcard.util.ListMultimap;
@@ -83,7 +84,9 @@ import ezvcard.util.StringUtils;
  * @see VCard#validate
  */
 public class ValidationWarnings implements Iterable<Map.Entry<VCardProperty, List<Warning>>> {
-	private final ListMultimap<VCardProperty, Warning> warnings = new ListMultimap<VCardProperty, Warning>();
+	private final ListMultimap<VCardProperty, Warning> warnings =
+		new ListMultimap<VCardProperty, Warning>(
+			new IdentityHashMap<VCardProperty, List<Warning>>());
 
 	/**
 	 * Adds a validation warning.

--- a/src/main/java/ezvcard/property/Address.java
+++ b/src/main/java/ezvcard/property/Address.java
@@ -9,6 +9,7 @@ import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.AddressType;
 import ezvcard.parameter.VCardParameters;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -86,6 +87,8 @@ import ezvcard.parameter.VCardParameters;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Address extends VCardProperty implements HasAltId {
 	private String poBox;
 	private String extendedAddress;

--- a/src/main/java/ezvcard/property/Agent.java
+++ b/src/main/java/ezvcard/property/Agent.java
@@ -10,6 +10,7 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.ValidationWarnings;
 import ezvcard.Warning;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -93,6 +94,8 @@ import ezvcard.Warning;
  * 
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Agent extends VCardProperty {
 	private String url;
 	private VCard vcard;

--- a/src/main/java/ezvcard/property/Anniversary.java
+++ b/src/main/java/ezvcard/property/Anniversary.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import ezvcard.VCardVersion;
 import ezvcard.util.PartialDate;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -101,6 +102,8 @@ import ezvcard.util.PartialDate;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Anniversary extends DateOrTimeProperty {
 	/**
 	 * Creates an anniversary property.

--- a/src/main/java/ezvcard/property/BinaryProperty.java
+++ b/src/main/java/ezvcard/property/BinaryProperty.java
@@ -11,6 +11,7 @@ import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.MediaTypeParameter;
 import ezvcard.util.IOUtils;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -46,6 +47,8 @@ import ezvcard.util.IOUtils;
  * @author Michael Angstadt
  * @param <T> the class used for representing the content type of the resource
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class BinaryProperty<T extends MediaTypeParameter> extends VCardProperty implements HasAltId {
 	/**
 	 * The decoded data.

--- a/src/main/java/ezvcard/property/Birthday.java
+++ b/src/main/java/ezvcard/property/Birthday.java
@@ -3,6 +3,7 @@ package ezvcard.property;
 import java.util.Date;
 
 import ezvcard.util.PartialDate;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -97,6 +98,8 @@ import ezvcard.util.PartialDate;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Birthday extends DateOrTimeProperty {
 	/**
 	 * Creates a birthday property.

--- a/src/main/java/ezvcard/property/Birthplace.java
+++ b/src/main/java/ezvcard/property/Birthplace.java
@@ -29,6 +29,8 @@ package ezvcard.property;
  either expressed or implied, of the FreeBSD Project.
  */
 
+import lombok.*;
+
 /**
  * <p>
  * Defines the location of the person's birth.
@@ -89,6 +91,8 @@ package ezvcard.property;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6474">RFC 6474</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Birthplace extends PlaceProperty {
 	/**
 	 * Creates a new birthplace property.

--- a/src/main/java/ezvcard/property/CalendarRequestUri.java
+++ b/src/main/java/ezvcard/property/CalendarRequestUri.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -60,6 +61,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class CalendarRequestUri extends UriProperty implements HasAltId {
 	/**
 	 * Creates a calendar request URI property.

--- a/src/main/java/ezvcard/property/CalendarUri.java
+++ b/src/main/java/ezvcard/property/CalendarUri.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -59,6 +60,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class CalendarUri extends UriProperty implements HasAltId {
 	/**
 	 * Creates a calendar URI property.

--- a/src/main/java/ezvcard/property/Categories.java
+++ b/src/main/java/ezvcard/property/Categories.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -62,6 +63,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Categories extends TextListProperty implements HasAltId {
 	@Override
 	public List<Integer[]> getPids() {

--- a/src/main/java/ezvcard/property/Classification.java
+++ b/src/main/java/ezvcard/property/Classification.java
@@ -4,6 +4,7 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -58,6 +59,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Classification extends TextProperty {
 	/**
 	 * Creates a classification property.

--- a/src/main/java/ezvcard/property/ClientPidMap.java
+++ b/src/main/java/ezvcard/property/ClientPidMap.java
@@ -9,6 +9,7 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.VCardParameters;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -90,6 +91,8 @@ import ezvcard.parameter.VCardParameters;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ClientPidMap extends VCardProperty {
 	private Integer pid;
 	private String uri;

--- a/src/main/java/ezvcard/property/DateOrTimeProperty.java
+++ b/src/main/java/ezvcard/property/DateOrTimeProperty.java
@@ -9,6 +9,7 @@ import ezvcard.Warning;
 import ezvcard.parameter.Calscale;
 import ezvcard.parameter.VCardParameters;
 import ezvcard.util.PartialDate;
+import lombok.*;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -43,6 +44,8 @@ import ezvcard.util.PartialDate;
  * Represents a property with a date and/or time value.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class DateOrTimeProperty extends VCardProperty implements HasAltId {
 	private String text;
 	private Date date;

--- a/src/main/java/ezvcard/property/Deathdate.java
+++ b/src/main/java/ezvcard/property/Deathdate.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import ezvcard.VCardVersion;
 import ezvcard.util.PartialDate;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -101,6 +103,8 @@ import ezvcard.util.PartialDate;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6474">RFC 6474</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Deathdate extends DateOrTimeProperty {
 	/**
 	 * Creates a deathdate property.

--- a/src/main/java/ezvcard/property/Deathplace.java
+++ b/src/main/java/ezvcard/property/Deathplace.java
@@ -29,6 +29,9 @@ package ezvcard.property;
  either expressed or implied, of the FreeBSD Project.
  */
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * <p>
  * Defines the location of the person's death.
@@ -89,6 +92,8 @@ package ezvcard.property;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6474">RFC 6474</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Deathplace extends PlaceProperty {
 	/**
 	 * Creates a new deathplace property.

--- a/src/main/java/ezvcard/property/Email.java
+++ b/src/main/java/ezvcard/property/Email.java
@@ -8,6 +8,8 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.EmailType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -68,6 +70,8 @@ import ezvcard.parameter.EmailType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Email extends TextProperty implements HasAltId {
 	/**
 	 * Creates an email property.

--- a/src/main/java/ezvcard/property/Expertise.java
+++ b/src/main/java/ezvcard/property/Expertise.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import ezvcard.VCardVersion;
 import ezvcard.parameter.ExpertiseLevel;
 import ezvcard.parameter.VCardParameters;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -65,6 +67,8 @@ import ezvcard.parameter.VCardParameters;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6715">RFC 6715</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Expertise extends TextProperty implements HasAltId {
 	/**
 	 * Creates an expertise property.

--- a/src/main/java/ezvcard/property/FormattedName.java
+++ b/src/main/java/ezvcard/property/FormattedName.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /*
@@ -55,6 +58,8 @@ import java.util.List;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class FormattedName extends TextProperty implements HasAltId {
 	/**
 	 * Creates a formatted name property.

--- a/src/main/java/ezvcard/property/FreeBusyUrl.java
+++ b/src/main/java/ezvcard/property/FreeBusyUrl.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -59,6 +61,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class FreeBusyUrl extends UriProperty implements HasAltId {
 	/**
 	 * Creates a free/busy URL property.

--- a/src/main/java/ezvcard/property/Gender.java
+++ b/src/main/java/ezvcard/property/Gender.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -76,6 +78,8 @@ import ezvcard.Warning;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Gender extends VCardProperty {
 	public static final String MALE = "M";
 	public static final String FEMALE = "F";

--- a/src/main/java/ezvcard/property/Geo.java
+++ b/src/main/java/ezvcard/property/Geo.java
@@ -6,6 +6,8 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.util.GeoUri;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -85,6 +87,8 @@ import ezvcard.util.GeoUri;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Geo extends VCardProperty implements HasAltId {
 	private GeoUri uri;
 

--- a/src/main/java/ezvcard/property/Hobby.java
+++ b/src/main/java/ezvcard/property/Hobby.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import ezvcard.VCardVersion;
 import ezvcard.parameter.HobbyLevel;
 import ezvcard.parameter.VCardParameters;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -65,6 +67,8 @@ import ezvcard.parameter.VCardParameters;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6715">RFC 6715</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Hobby extends TextProperty implements HasAltId {
 	/**
 	 * Creates a hobby property.

--- a/src/main/java/ezvcard/property/ImageProperty.java
+++ b/src/main/java/ezvcard/property/ImageProperty.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import ezvcard.parameter.ImageType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -39,6 +41,8 @@ import ezvcard.parameter.ImageType;
  * Represents a vCard property that stores image data.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ImageProperty extends BinaryProperty<ImageType> {
 	/**
 	 * Creates an image property.

--- a/src/main/java/ezvcard/property/Impp.java
+++ b/src/main/java/ezvcard/property/Impp.java
@@ -11,6 +11,8 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.ImppType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -72,6 +74,8 @@ import ezvcard.parameter.ImppType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Impp extends VCardProperty implements HasAltId {
 	private static final String AIM = "aim";
 	private static final String ICQ = "icq";

--- a/src/main/java/ezvcard/property/Interest.java
+++ b/src/main/java/ezvcard/property/Interest.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import ezvcard.VCardVersion;
 import ezvcard.parameter.InterestLevel;
 import ezvcard.parameter.VCardParameters;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -65,6 +67,8 @@ import ezvcard.parameter.VCardParameters;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6715">RFC 6715</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Interest extends TextProperty implements HasAltId {
 	/**
 	 * Creates an interest property.

--- a/src/main/java/ezvcard/property/Key.java
+++ b/src/main/java/ezvcard/property/Key.java
@@ -9,6 +9,8 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.KeyType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -103,6 +105,8 @@ import ezvcard.parameter.KeyType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Key extends BinaryProperty<KeyType> {
 	private String text;
 

--- a/src/main/java/ezvcard/property/Kind.java
+++ b/src/main/java/ezvcard/property/Kind.java
@@ -4,6 +4,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -74,6 +76,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Kind extends TextProperty {
 	public static final String INDIVIDUAL = "individual";
 	public static final String GROUP = "group";

--- a/src/main/java/ezvcard/property/Label.java
+++ b/src/main/java/ezvcard/property/Label.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.parameter.AddressType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -79,6 +81,8 @@ import ezvcard.parameter.AddressType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Label extends TextProperty {
 	/**
 	 * Creates a label property.

--- a/src/main/java/ezvcard/property/Language.java
+++ b/src/main/java/ezvcard/property/Language.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -65,6 +67,8 @@ import ezvcard.VCardVersion;
  * 
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Language extends TextProperty implements HasAltId {
 	/**
 	 * Creates a language property.

--- a/src/main/java/ezvcard/property/Logo.java
+++ b/src/main/java/ezvcard/property/Logo.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import ezvcard.parameter.ImageType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -88,6 +90,8 @@ import ezvcard.parameter.ImageType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Logo extends ImageProperty {
 	/**
 	 * Creates a logo property.

--- a/src/main/java/ezvcard/property/Mailer.java
+++ b/src/main/java/ezvcard/property/Mailer.java
@@ -4,6 +4,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -58,6 +60,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Mailer extends TextProperty {
 	/**
 	 * Creates a mailer property.

--- a/src/main/java/ezvcard/property/Member.java
+++ b/src/main/java/ezvcard/property/Member.java
@@ -8,6 +8,8 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.util.TelUri;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -71,6 +73,8 @@ import ezvcard.util.TelUri;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Member extends UriProperty implements HasAltId {
 	/**
 	 * Creates a member property.

--- a/src/main/java/ezvcard/property/Nickname.java
+++ b/src/main/java/ezvcard/property/Nickname.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -62,6 +64,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Nickname extends TextListProperty implements HasAltId {
 	@Override
 	public Set<VCardVersion> _supportedVersions() {

--- a/src/main/java/ezvcard/property/Note.java
+++ b/src/main/java/ezvcard/property/Note.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /*
@@ -55,6 +58,8 @@ import java.util.List;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Note extends TextProperty implements HasAltId {
 	/**
 	 * Creates a note property.

--- a/src/main/java/ezvcard/property/OrgDirectory.java
+++ b/src/main/java/ezvcard/property/OrgDirectory.java
@@ -4,6 +4,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -60,6 +62,8 @@ import ezvcard.VCardVersion;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6715">RFC 6715</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class OrgDirectory extends UriProperty implements HasAltId {
 	/**
 	 * @param uri the URI

--- a/src/main/java/ezvcard/property/Organization.java
+++ b/src/main/java/ezvcard/property/Organization.java
@@ -3,6 +3,8 @@ package ezvcard.property;
 import java.util.List;
 
 import ezvcard.parameter.VCardParameters;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -61,6 +63,8 @@ import ezvcard.parameter.VCardParameters;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Organization extends TextListProperty implements HasAltId {
 	@Override
 	public String getLanguage() {

--- a/src/main/java/ezvcard/property/Photo.java
+++ b/src/main/java/ezvcard/property/Photo.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import ezvcard.parameter.ImageType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -88,6 +90,8 @@ import ezvcard.parameter.ImageType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Photo extends ImageProperty {
 	/**
 	 * Creates a photo property.

--- a/src/main/java/ezvcard/property/PlaceProperty.java
+++ b/src/main/java/ezvcard/property/PlaceProperty.java
@@ -8,6 +8,8 @@ import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.util.GeoUri;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -43,6 +45,8 @@ import ezvcard.util.GeoUri;
  * @author Michael Angstadt
  * @see <a href="http://tools.ietf.org/html/rfc6474">RFC 6474</a>
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class PlaceProperty extends VCardProperty implements HasAltId {
 	protected GeoUri geoUri;
 	protected String uri;

--- a/src/main/java/ezvcard/property/ProductId.java
+++ b/src/main/java/ezvcard/property/ProductId.java
@@ -4,6 +4,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -58,6 +60,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ProductId extends TextProperty {
 	/**
 	 * Creates a product ID property.

--- a/src/main/java/ezvcard/property/Profile.java
+++ b/src/main/java/ezvcard/property/Profile.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -61,6 +63,8 @@ import ezvcard.Warning;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Profile extends TextProperty {
 	public Profile() {
 		super("VCARD");

--- a/src/main/java/ezvcard/property/RawProperty.java
+++ b/src/main/java/ezvcard/property/RawProperty.java
@@ -5,6 +5,8 @@ import java.util.regex.Pattern;
 
 import ezvcard.VCard;
 import ezvcard.VCardDataType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
 
@@ -42,6 +44,8 @@ import ezvcard.Warning;
  * value.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class RawProperty extends TextProperty {
 	private String propertyName;
 	private VCardDataType dataType;

--- a/src/main/java/ezvcard/property/Related.java
+++ b/src/main/java/ezvcard/property/Related.java
@@ -10,6 +10,8 @@ import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.RelatedType;
 import ezvcard.util.TelUri;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -78,6 +80,8 @@ import ezvcard.util.TelUri;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Related extends VCardProperty implements HasAltId {
 	private String uri;
 	private String text;

--- a/src/main/java/ezvcard/property/Revision.java
+++ b/src/main/java/ezvcard/property/Revision.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.Date;
 
 /*
@@ -55,6 +58,8 @@ import java.util.Date;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Revision extends SimpleProperty<Date> {
 	/**
 	 * Creates a revision property.

--- a/src/main/java/ezvcard/property/Role.java
+++ b/src/main/java/ezvcard/property/Role.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /*
@@ -55,6 +58,8 @@ import java.util.List;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Role extends TextProperty implements HasAltId {
 	/**
 	 * Creates a role property.

--- a/src/main/java/ezvcard/property/SimpleProperty.java
+++ b/src/main/java/ezvcard/property/SimpleProperty.java
@@ -5,6 +5,8 @@ import java.util.List;
 import ezvcard.VCard;
 import ezvcard.VCardVersion;
 import ezvcard.Warning;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -40,6 +42,8 @@ import ezvcard.Warning;
  * @param <T> the class of the property's value
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class SimpleProperty<T> extends VCardProperty {
 	protected T value;
 

--- a/src/main/java/ezvcard/property/SortString.java
+++ b/src/main/java/ezvcard/property/SortString.java
@@ -4,6 +4,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -83,6 +85,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class SortString extends TextProperty {
 	/**
 	 * Creates a sort-string property.

--- a/src/main/java/ezvcard/property/Sound.java
+++ b/src/main/java/ezvcard/property/Sound.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import ezvcard.parameter.SoundType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -88,6 +90,8 @@ import ezvcard.parameter.SoundType;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Sound extends BinaryProperty<SoundType> {
 	/**
 	 * Creates a sound property.

--- a/src/main/java/ezvcard/property/Source.java
+++ b/src/main/java/ezvcard/property/Source.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /*
@@ -56,6 +59,8 @@ import java.util.List;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Source extends UriProperty implements HasAltId {
 	/**
 	 * Creates a source property.

--- a/src/main/java/ezvcard/property/SourceDisplayText.java
+++ b/src/main/java/ezvcard/property/SourceDisplayText.java
@@ -4,6 +4,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import ezvcard.VCardVersion;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -58,6 +60,8 @@ import ezvcard.VCardVersion;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class SourceDisplayText extends TextProperty {
 	/**
 	 * Creates a source display text property.

--- a/src/main/java/ezvcard/property/StructuredName.java
+++ b/src/main/java/ezvcard/property/StructuredName.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import ezvcard.parameter.VCardParameters;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -62,6 +64,8 @@ import ezvcard.parameter.VCardParameters;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class StructuredName extends VCardProperty implements HasAltId {
 	private String family;
 	private String given;

--- a/src/main/java/ezvcard/property/Telephone.java
+++ b/src/main/java/ezvcard/property/Telephone.java
@@ -9,6 +9,8 @@ import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.TelephoneType;
 import ezvcard.util.TelUri;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -73,6 +75,8 @@ import ezvcard.util.TelUri;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Telephone extends VCardProperty implements HasAltId {
 	private String text;
 	private TelUri uri;

--- a/src/main/java/ezvcard/property/TextListProperty.java
+++ b/src/main/java/ezvcard/property/TextListProperty.java
@@ -29,10 +29,15 @@ package ezvcard.property;
  either expressed or implied, of the FreeBSD Project.
  */
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * Represents a property whose value is a list of textual values.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class TextListProperty extends ListProperty<String> {
 	//empty
 }

--- a/src/main/java/ezvcard/property/TextProperty.java
+++ b/src/main/java/ezvcard/property/TextProperty.java
@@ -29,10 +29,15 @@ package ezvcard.property;
  either expressed or implied, of the FreeBSD Project.
  */
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * Represents a property whose value is just a regular text value.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class TextProperty extends SimpleProperty<String> {
 	/**
 	 * Creates a property that contains text.

--- a/src/main/java/ezvcard/property/Timezone.java
+++ b/src/main/java/ezvcard/property/Timezone.java
@@ -9,6 +9,8 @@ import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.util.UtcOffset;
 import ezvcard.util.VCardDateFormat;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /*
  Copyright (c) 2012-2015, Michael Angstadt
@@ -69,6 +71,8 @@ import ezvcard.util.VCardDateFormat;
  * 
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Timezone extends VCardProperty implements HasAltId {
 	private UtcOffset offset;
 	private String text;

--- a/src/main/java/ezvcard/property/Title.java
+++ b/src/main/java/ezvcard/property/Title.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /*
@@ -56,6 +59,8 @@ import java.util.List;
  * 
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Title extends TextProperty implements HasAltId {
 	/**
 	 * Creates a title property.

--- a/src/main/java/ezvcard/property/Uid.java
+++ b/src/main/java/ezvcard/property/Uid.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.UUID;
 
 /*
@@ -59,6 +62,8 @@ import java.util.UUID;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Uid extends UriProperty {
 	/**
 	 * Creates a UID property.

--- a/src/main/java/ezvcard/property/UriProperty.java
+++ b/src/main/java/ezvcard/property/UriProperty.java
@@ -29,10 +29,15 @@ package ezvcard.property;
  either expressed or implied, of the FreeBSD Project.
  */
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /**
  * Represents a property whose value is a URI.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class UriProperty extends TextProperty {
 	/**
 	 * Creates a property whose value is a URI.

--- a/src/main/java/ezvcard/property/Url.java
+++ b/src/main/java/ezvcard/property/Url.java
@@ -1,5 +1,8 @@
 package ezvcard.property;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /*
@@ -55,6 +58,8 @@ import java.util.List;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Url extends UriProperty implements HasAltId {
 	/**
 	 * Creates a URL property.

--- a/src/main/java/ezvcard/property/VCardProperty.java
+++ b/src/main/java/ezvcard/property/VCardProperty.java
@@ -12,6 +12,9 @@ import ezvcard.VCardVersion;
 import ezvcard.Warning;
 import ezvcard.parameter.VCardParameters;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /*
  Copyright (c) 2012-2015, Michael Angstadt
  All rights reserved.
@@ -45,6 +48,8 @@ import ezvcard.parameter.VCardParameters;
  * Base class for all vCard property classes.
  * @author Michael Angstadt
  */
+@EqualsAndHashCode
+@ToString
 public abstract class VCardProperty implements Comparable<VCardProperty> {
 	/**
 	 * The group that this property belongs to or null if it doesn't belong to a

--- a/src/main/java/ezvcard/property/Xml.java
+++ b/src/main/java/ezvcard/property/Xml.java
@@ -3,6 +3,8 @@ package ezvcard.property;
 import java.util.EnumSet;
 import java.util.Set;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -65,6 +67,8 @@ import ezvcard.util.XmlUtils;
  * </p>
  * @author Michael Angstadt
  */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Xml extends SimpleProperty<Document> implements HasAltId {
 	/**
 	 * Creates an XML property.

--- a/src/main/java/ezvcard/util/ListMultimap.java
+++ b/src/main/java/ezvcard/util/ListMultimap.java
@@ -57,6 +57,13 @@ public class ListMultimap<K, V> implements Iterable<Map.Entry<K, List<V>>> {
 	}
 
 	/**
+	 * Creates a multimap using a specific backing map.
+	 */
+	public ListMultimap(Map<K, List<V>> backingMap) {
+		map = backingMap;
+	}
+
+	/**
 	 * Creates an empty multimap.
 	 * @param initialCapacity the initial capacity of the underlying map.
 	 */

--- a/src/test/java/ezvcard/ValidationWarningsTest.java
+++ b/src/test/java/ezvcard/ValidationWarningsTest.java
@@ -5,7 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.*;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -63,7 +64,10 @@ public class ValidationWarningsTest {
 		warnings.add(new TestProperty2(), v2);
 		warnings.add(null, v3);
 
-		assertEquals(Arrays.asList(v0, v1), warnings.getByProperty(TestProperty1.class));
+		Set<Warning> v0Warnings = new HashSet<Warning>(
+			warnings.getByProperty(TestProperty1.class));
+		assertEquals(new HashSet<Warning>(Arrays.asList(v0, v1)), v0Warnings);
+
 		assertEquals(Arrays.asList(v2), warnings.getByProperty(TestProperty2.class));
 		assertEquals(Arrays.asList(v3), warnings.getByProperty(null));
 		assertEquals(Arrays.asList(), warnings.getByProperty(TestProperty3.class));
@@ -79,14 +83,18 @@ public class ValidationWarningsTest {
 		warnings.add(new TestProperty1(), new Warning("four", 4));
 
 		//@formatter:off
-		String expected =
-		"one" + NEWLINE +
-		"W02: two" + NEWLINE +
-		"[TestProperty1] | three" + NEWLINE +
-		"[TestProperty1] | W04: four" + NEWLINE;
+		List<String> expected = Arrays.asList(
+			"one",
+			"W02: two",
+			"[TestProperty1] | three",
+			"[TestProperty1] | W04: four");
 		//@formatter:on
+		// XXX warning ordering is dependent on IdentityHashMap ordering, so sort lines.
+		Collections.sort(expected);
 		String actual = warnings.toString();
-		assertEquals(expected, actual);
+		List<String> actualSplit = Arrays.asList(Pattern.compile(NEWLINE).split(actual));
+		Collections.sort(actualSplit);
+		assertEquals(expected, actualSplit);
 	}
 
 	private class TestProperty1 extends VCardProperty {


### PR DESCRIPTION
In the name of fork parity, plus equals/hashcode/tostring are generally useful.

I'm using lombok to generate these, which requires java 1.6. If you have users stuck on 1.5, you could manually delombok all the generated code, but if not, you really should like lombok, it's great.