### PR TITLE
Added indentation using Jackson PrettyPrinter

### DIFF
--- a/src/main/java/ezvcard/io/chain/ChainingJsonWriter.java
+++ b/src/main/java/ezvcard/io/chain/ChainingJsonWriter.java
@@ -129,7 +129,7 @@ public class ChainingJsonWriter extends ChainingWriter<ChainingJsonWriter> {
 
 	private void go(JCardWriter writer) throws IOException {
 		writer.setAddProdId(prodId);
-		writer.setIndent(indent);
+		writer.setPrettyPrint(indent);
 		writer.setVersionStrict(versionStrict);
 		if (index != null) {
 			writer.setScribeIndex(index);

--- a/src/main/java/ezvcard/io/json/JCardWriter.java
+++ b/src/main/java/ezvcard/io/json/JCardWriter.java
@@ -1,24 +1,19 @@
 package ezvcard.io.json;
 
-import static ezvcard.util.IOUtils.utf8Writer;
+import static ezvcard.util.IOUtils.*;
 
-import java.io.File;
-import java.io.Flushable;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Writer;
+import java.io.*;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.PrettyPrinter;
 
 import ezvcard.*;
-import ezvcard.io.EmbeddedVCardException;
-import ezvcard.io.SkipMeException;
-import ezvcard.io.StreamWriter;
+import ezvcard.io.*;
 import ezvcard.io.scribe.VCardPropertyScribe;
 import ezvcard.parameter.VCardParameters;
-import ezvcard.property.TextProperty;
 import ezvcard.property.VCardProperty;
+import ezvcard.util.JCardPrettyPrinter;
 
 /*
  Copyright (c) 2012-2016, Michael Angstadt
@@ -221,20 +216,48 @@ public class JCardWriter extends StreamWriter implements Flushable {
 	}
 
 	/**
+	 * @deprecated Since 1.9.10 use {@link #isPrettyPrint}
+	 */
+	@Deprecated
+	public boolean isIndent() {
+		return writer.isPrettyPrint();
+	}
+
+	/**
+	 * @deprecated Since 1.9.10 use {@link #setPrettyPrint}
+	 */
+	@Deprecated
+	public void setIndent(boolean indent) {
+		writer.setPrettyPrint(indent);
+	}
+
+	/**
 	 * Gets whether or not the JSON will be pretty-printed.
 	 * @return true if it will be pretty-printed, false if not (defaults to
 	 * false)
 	 */
-	public boolean isIndent() {
-		return writer.isIndent();
+	public boolean isPrettyPrint() {
+		return writer.isPrettyPrint();
 	}
 
 	/**
 	 * Sets whether or not to pretty-print the JSON.
 	 * @param indent true to pretty-print it, false not to (defaults to false)
 	 */
-	public void setIndent(boolean indent) {
-		writer.setIndent(indent);
+	public void setPrettyPrint(boolean prettyPrint) {
+		writer.setPrettyPrint(prettyPrint);
+	}
+
+	/**
+	 * Sets the pretty printer to pretty-print the JSON with. Note that this
+	 * method implicitly enables indenting, so {@code setPrettyPrint(true)} does
+	 * not also need to be called.
+	 * @param prettyPrinter the custom pretty printer (defaults to an instance
+	 * of {@link JCardPrettyPrinter}, if {@code setPrettyPrint(true)} has been
+	 * called.
+	 */
+	public void setPrettyPrinter(PrettyPrinter prettyPrinter) {
+		writer.setPrettyPrinter(prettyPrinter);
 	}
 
 	/**

--- a/src/main/java/ezvcard/util/JCardPrettyPrinter.java
+++ b/src/main/java/ezvcard/util/JCardPrettyPrinter.java
@@ -1,0 +1,101 @@
+package ezvcard.util;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+import ezvcard.VCardVersion;
+import ezvcard.property.VCardProperty;
+
+public class JCardPrettyPrinter extends DefaultPrettyPrinter {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Alias for {@link DefaultIndenter#SYSTEM_LINEFEED_INSTANCE}
+	 */
+	public static final Indenter NEWLINE_INDENTER = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
+	/**
+	 * Instance of {@link DefaultPrettyPrinter.FixedSpaceIndenter}
+	 */
+	public static final Indenter INLINE_INDENTER = new DefaultPrettyPrinter.FixedSpaceIndenter();
+
+	private Indenter propertyIndenter = INLINE_INDENTER;
+	private Indenter arrayIndenter = NEWLINE_INDENTER;
+	private Indenter objectIndenter = NEWLINE_INDENTER;
+
+	public JCardPrettyPrinter() {
+		super.indentArraysWith(arrayIndenter);
+		super.indentObjectsWith(objectIndenter);
+	}
+	
+	public JCardPrettyPrinter(JCardPrettyPrinter base) {
+		super(base);
+		this.propertyIndenter = base.propertyIndenter;
+		this.arrayIndenter = base.arrayIndenter;
+		this.objectIndenter = base.objectIndenter;
+		super.indentArraysWith(arrayIndenter);
+		super.indentObjectsWith(objectIndenter);
+	}
+	
+	@Override
+	public DefaultPrettyPrinter createInstance() {
+		return new JCardPrettyPrinter(this);
+	}
+
+	@Override
+	public void indentArraysWith(Indenter i) {
+		arrayIndenter = i;
+		super.indentArraysWith(i);
+	}
+
+	@Override
+	public void indentObjectsWith(Indenter i) {
+		objectIndenter = i;
+		super.indentObjectsWith(i);
+	}
+
+	public void indentVCardPropertiesWith(Indenter i) {
+		propertyIndenter = i;
+	}
+
+	protected static boolean isInVCardProperty(JsonStreamContext context) {
+		if (context == null) {
+			return false;
+		} else if (context.getCurrentValue() instanceof VCardProperty
+				|| context.getCurrentValue() instanceof VCardVersion) {
+			return true;
+		} else {
+			return isInVCardProperty(context.getParent());
+		}
+	}
+
+	private void updateIndenter(JsonStreamContext context) {
+		if (isInVCardProperty(context)) {
+			super.indentArraysWith(propertyIndenter);
+			super.indentObjectsWith(propertyIndenter);
+		} else {
+			super.indentArraysWith(arrayIndenter);
+			super.indentObjectsWith(objectIndenter);
+		}
+	}
+
+	@Override
+	public void writeStartArray(JsonGenerator gen) throws IOException, JsonGenerationException {
+		updateIndenter(gen.getOutputContext().getParent());
+		super.writeStartArray(gen);
+	}
+
+	@Override
+	public void writeEndArray(JsonGenerator gen, int nrOfValues) throws IOException, JsonGenerationException {
+		updateIndenter(gen.getOutputContext().getParent());
+		super.writeEndArray(gen, nrOfValues);
+	}
+
+	@Override
+	public void writeArrayValueSeparator(JsonGenerator gen) throws IOException {
+		updateIndenter(gen.getOutputContext().getParent());
+		super.writeArrayValueSeparator(gen);
+	}
+}

--- a/src/test/java/ezvcard/EzvcardTest.java
+++ b/src/test/java/ezvcard/EzvcardTest.java
@@ -738,7 +738,7 @@ public class EzvcardTest {
 		assertTrue(actual.startsWith("[\"vcard\",[[\""));
 
 		actual = Ezvcard.writeJson(vcard).indent(true).go();
-		assertTrue(actual.startsWith("[" + NEWLINE + "\"vcard\",[[" + NEWLINE));
+		assertTrue(actual.startsWith("[" + NEWLINE + "  \"vcard\"," + NEWLINE + "  [" + NEWLINE + "    ["));
 
 		actual = Ezvcard.writeJson(vcard).indent(false).go();
 		assertTrue(actual.startsWith("[\"vcard\",[[\""));

--- a/src/test/java/ezvcard/io/json/JCardRawWriterTest.java
+++ b/src/test/java/ezvcard/io/json/JCardRawWriterTest.java
@@ -348,11 +348,18 @@ public class JCardRawWriterTest {
 		String expected =
 		"[" + NEWLINE +
 		"[" + NEWLINE +
-		"\"vcard\",[[" + NEWLINE +
-		"  \"prop1\",{},\"text\",\"value1\"],[" + NEWLINE +
-		"  \"prop2\",{},\"text\",\"value2\"]]],[" + NEWLINE +
-		"\"vcard\",[[" + NEWLINE +
-		"  \"prop3\",{},\"text\",\"value3\"]]]" + NEWLINE +
+		"  \"vcard\"," + NEWLINE +
+		"  [" + NEWLINE +
+		"    [ \"prop1\", { }, \"text\", \"value1\" ]," + NEWLINE +
+		"    [ \"prop2\", { }, \"text\", \"value2\" ]" + NEWLINE +
+		"  ]" + NEWLINE +
+		"]," + NEWLINE +
+		"[" + NEWLINE +
+		"  \"vcard\"," + NEWLINE +
+		"  [" + NEWLINE +
+		"    [ \"prop3\", { }, \"text\", \"value3\" ]" + NEWLINE +
+		"  ]" + NEWLINE +
+		"]" + NEWLINE +
 		"]";
 		//@formatter:on
 		assertEquals(expected, actual);

--- a/src/test/java/ezvcard/io/json/JCardRawWriterTest.java
+++ b/src/test/java/ezvcard/io/json/JCardRawWriterTest.java
@@ -330,7 +330,7 @@ public class JCardRawWriterTest {
 	public void indent() throws Throwable {
 		StringWriter sw = new StringWriter();
 		JCardRawWriter writer = new JCardRawWriter(sw, true);
-		writer.setIndent(true);
+		writer.setPrettyPrint(true);
 
 		//@formatter:off
 		writer.writeStartVCard();
@@ -347,19 +347,19 @@ public class JCardRawWriterTest {
 		//@formatter:off
 		String expected =
 		"[" + NEWLINE +
-		"[" + NEWLINE +
-		"  \"vcard\"," + NEWLINE +
 		"  [" + NEWLINE +
-		"    [ \"prop1\", { }, \"text\", \"value1\" ]," + NEWLINE +
-		"    [ \"prop2\", { }, \"text\", \"value2\" ]" + NEWLINE +
-		"  ]" + NEWLINE +
-		"]," + NEWLINE +
-		"[" + NEWLINE +
-		"  \"vcard\"," + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"prop1\", { }, \"text\", \"value1\" ]," + NEWLINE +
+		"      [ \"prop2\", { }, \"text\", \"value2\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
+		"  ]," + NEWLINE +
 		"  [" + NEWLINE +
-		"    [ \"prop3\", { }, \"text\", \"value3\" ]" + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"prop3\", { }, \"text\", \"value3\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
 		"  ]" + NEWLINE +
-		"]" + NEWLINE +
 		"]";
 		//@formatter:on
 		assertEquals(expected, actual);

--- a/src/test/java/ezvcard/io/json/JCardSerializerTest.java
+++ b/src/test/java/ezvcard/io/json/JCardSerializerTest.java
@@ -3,19 +3,23 @@ package ezvcard.io.json;
 import static ezvcard.util.StringUtils.NEWLINE;
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
-import com.fasterxml.jackson.core.util.DefaultIndenter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.util.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import ezvcard.VCard;
+import ezvcard.VCardVersion;
+import ezvcard.property.VCardProperty;
 
 /*
  Copyright (c) 2012-2016, Michael Angstadt
@@ -114,6 +118,42 @@ public class JCardSerializerTest {
 		VCard example = JCardWriterTest.createExample();
 		String actual = getMapper().writeValueAsString(example);
 		JCardWriterTest.assertExample(actual, "jcard-example.json");
+	}
+
+	@Test
+	public void check_context_set() throws Throwable {
+		VCard example = JCardWriterTest.createExample();
+		ObjectMapper mapper = getMapper();
+		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+		mapper.setDefaultPrettyPrinter(new MinimalPrettyPrinter() {
+			private static final long serialVersionUID = 1L;
+
+			private boolean find(JsonStreamContext context, Class<?>... classes) {
+				if (context == null) {
+					return false;
+				} else {
+					for (Class<?> type : classes) {
+						if (type.isInstance(context.getCurrentValue())) {
+							return true;
+						}
+					}
+					return find(context.getParent(), classes);
+				}
+			}
+
+			public void writeStartObject(JsonGenerator gen) throws JsonGenerationException, IOException {
+				Assert.assertTrue("Written VCard parameter was not within a VCardProperty context",
+						find(gen.getOutputContext(), VCardProperty.class, VCardVersion.class));
+				super.writeStartObject(gen);
+			}
+
+			public void writeStartArray(JsonGenerator gen) throws JsonGenerationException, IOException {
+				Assert.assertTrue("Written value was not within a VCard context",
+						find(gen.getOutputContext(), VCard.class));
+				super.writeStartArray(gen);
+			}
+		});
+		mapper.writeValueAsString(example);
 	}
 
 	@Test

--- a/src/test/java/ezvcard/io/json/JCardSerializerTest.java
+++ b/src/test/java/ezvcard/io/json/JCardSerializerTest.java
@@ -1,25 +1,19 @@
 package ezvcard.io.json;
 
-import static ezvcard.util.StringUtils.NEWLINE;
-import static org.junit.Assert.assertEquals;
+import static ezvcard.util.StringUtils.*;
+import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.core.util.*;
+import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import ezvcard.VCard;
-import ezvcard.VCardVersion;
-import ezvcard.property.VCardProperty;
+import ezvcard.util.JCardPrettyPrinter;
 
 /*
  Copyright (c) 2012-2016, Michael Angstadt
@@ -64,8 +58,7 @@ public class JCardSerializerTest {
 
 		ObjectMapper mapper = getMapper();
 
-		final DefaultPrettyPrinter pp = new DefaultPrettyPrinter();
-		pp.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+		final PrettyPrinter pp = new JCardPrettyPrinter();
 		mapper.setDefaultPrettyPrinter(pp);
 		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
 
@@ -73,41 +66,21 @@ public class JCardSerializerTest {
 
 		//@formatter:off
 		String expected =
-		"[" + NEWLINE + 
-		"  [" + NEWLINE + 
-		"    \"vcard\"," + NEWLINE + 
-		"    [" + NEWLINE + 
-		"      [" + NEWLINE + 
-		"        \"version\"," + NEWLINE + 
-		"        { }," + NEWLINE + 
-		"        \"text\"," + NEWLINE + 
-		"        \"4.0\"" + NEWLINE + 
-		"      ]," + NEWLINE + 
-		"      [" + NEWLINE + 
-		"        \"fn\"," + NEWLINE + 
-		"        { }," + NEWLINE + 
-		"        \"text\"," + NEWLINE + 
-		"        \"John Doe\"" + NEWLINE + 
-		"      ]" + NEWLINE + 
-		"    ]" + NEWLINE + 
-		"  ]," + NEWLINE + 
-		"  [" + NEWLINE + 
-		"    \"vcard\"," + NEWLINE + 
-		"    [" + NEWLINE + 
-		"      [" + NEWLINE + 
-		"        \"version\"," + NEWLINE + 
-		"        { }," + NEWLINE + 
-		"        \"text\"," + NEWLINE + 
-		"        \"4.0\"" + NEWLINE + 
-		"      ]," + NEWLINE + 
-		"      [" + NEWLINE + 
-		"        \"fn\"," + NEWLINE + 
-		"        { }," + NEWLINE + 
-		"        \"text\"," + NEWLINE + 
-		"        \"John Doe\"" + NEWLINE + 
-		"      ]" + NEWLINE + 
-		"    ]" + NEWLINE + 
-		"  ]" + NEWLINE + 
+		"[" + NEWLINE +
+		"  [" + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"      [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
+		"  ]," + NEWLINE +
+		"  [" + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"      [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
+		"  ]" + NEWLINE +
 		"]";
 		//@formatter:on
 		assertEquals(expected, result);
@@ -118,42 +91,6 @@ public class JCardSerializerTest {
 		VCard example = JCardWriterTest.createExample();
 		String actual = getMapper().writeValueAsString(example);
 		JCardWriterTest.assertExample(actual, "jcard-example.json");
-	}
-
-	@Test
-	public void check_context_set() throws Throwable {
-		VCard example = JCardWriterTest.createExample();
-		ObjectMapper mapper = getMapper();
-		mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-		mapper.setDefaultPrettyPrinter(new MinimalPrettyPrinter() {
-			private static final long serialVersionUID = 1L;
-
-			private boolean find(JsonStreamContext context, Class<?>... classes) {
-				if (context == null) {
-					return false;
-				} else {
-					for (Class<?> type : classes) {
-						if (type.isInstance(context.getCurrentValue())) {
-							return true;
-						}
-					}
-					return find(context.getParent(), classes);
-				}
-			}
-
-			public void writeStartObject(JsonGenerator gen) throws JsonGenerationException, IOException {
-				Assert.assertTrue("Written VCard parameter was not within a VCardProperty context",
-						find(gen.getOutputContext(), VCardProperty.class, VCardVersion.class));
-				super.writeStartObject(gen);
-			}
-
-			public void writeStartArray(JsonGenerator gen) throws JsonGenerationException, IOException {
-				Assert.assertTrue("Written value was not within a VCard context",
-						find(gen.getOutputContext(), VCard.class));
-				super.writeStartArray(gen);
-			}
-		});
-		mapper.writeValueAsString(example);
 	}
 
 	@Test

--- a/src/test/java/ezvcard/io/json/JCardWriterTest.java
+++ b/src/test/java/ezvcard/io/json/JCardWriterTest.java
@@ -155,12 +155,19 @@ public class JCardWriterTest {
 		String expected =
 		"[" + NEWLINE +
 		"[" + NEWLINE +
-		"\"vcard\",[[" + NEWLINE +
-		"  \"version\",{},\"text\",\"4.0\"],[" + NEWLINE +
-		"  \"fn\",{},\"text\",\"John Doe\"]]],[" + NEWLINE +
-		"\"vcard\",[[" + NEWLINE +
-		"  \"version\",{},\"text\",\"4.0\"],[" + NEWLINE +
-		"  \"fn\",{},\"text\",\"John Doe\"]]]" + NEWLINE +
+		"  \"vcard\"," + NEWLINE +
+		"  [" + NEWLINE +
+		"    [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"    [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"  ]" + NEWLINE +
+		"]," + NEWLINE +
+		"[" + NEWLINE +
+		"  \"vcard\"," + NEWLINE +
+		"  [" + NEWLINE +
+		"    [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"    [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"  ]" + NEWLINE +
+		"]" + NEWLINE +
 		"]";
 		//@formatter:on
 		assertEquals(expected, sw.toString());

--- a/src/test/java/ezvcard/io/json/JCardWriterTest.java
+++ b/src/test/java/ezvcard/io/json/JCardWriterTest.java
@@ -33,10 +33,7 @@ import ezvcard.property.StructuredName;
 import ezvcard.property.Telephone;
 import ezvcard.property.Timezone;
 import ezvcard.property.VCardProperty;
-import ezvcard.util.IOUtils;
-import ezvcard.util.PartialDate;
-import ezvcard.util.TelUri;
-import ezvcard.util.UtcOffset;
+import ezvcard.util.*;
 
 /*
  Copyright (c) 2012-2016, Michael Angstadt
@@ -135,11 +132,11 @@ public class JCardWriterTest {
 	}
 
 	@Test
-	public void setIndent() throws Throwable {
+	public void setPrettyPrint() throws Throwable {
 		StringWriter sw = new StringWriter();
 		JCardWriter writer = new JCardWriter(sw, true);
 		writer.setAddProdId(false);
-		writer.setIndent(true);
+		writer.setPrettyPrint(true);
 
 		VCard vcard = new VCard();
 		vcard.setFormattedName("John Doe");
@@ -154,20 +151,59 @@ public class JCardWriterTest {
 		//@formatter:off
 		String expected =
 		"[" + NEWLINE +
-		"[" + NEWLINE +
-		"  \"vcard\"," + NEWLINE +
 		"  [" + NEWLINE +
-		"    [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
-		"    [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
-		"  ]" + NEWLINE +
-		"]," + NEWLINE +
-		"[" + NEWLINE +
-		"  \"vcard\"," + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"      [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
+		"  ]," + NEWLINE +
 		"  [" + NEWLINE +
-		"    [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
-		"    [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"      [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
 		"  ]" + NEWLINE +
-		"]" + NEWLINE +
+		"]";
+		//@formatter:on
+		assertEquals(expected, sw.toString());
+	}
+
+	@Test
+	public void setPrettyPrinter() throws Throwable {
+		StringWriter sw = new StringWriter();
+		JCardWriter writer = new JCardWriter(sw, true);
+		writer.setAddProdId(false);
+		writer.setPrettyPrinter(new JCardPrettyPrinter());
+
+		VCard vcard = new VCard();
+		vcard.setFormattedName("John Doe");
+		writer.write(vcard);
+
+		vcard = new VCard();
+		vcard.setFormattedName("John Doe");
+		writer.write(vcard);
+
+		writer.close();
+
+		//@formatter:off
+		String expected =
+		"[" + NEWLINE +
+		"  [" + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"      [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
+		"  ]," + NEWLINE +
+		"  [" + NEWLINE +
+		"    \"vcard\"," + NEWLINE +
+		"    [" + NEWLINE +
+		"      [ \"version\", { }, \"text\", \"4.0\" ]," + NEWLINE +
+		"      [ \"fn\", { }, \"text\", \"John Doe\" ]" + NEWLINE +
+		"    ]" + NEWLINE +
+		"  ]" + NEWLINE +
 		"]";
 		//@formatter:on
 		assertEquals(expected, sw.toString());


### PR DESCRIPTION
Continuing the discussion from https://github.com/bgorven/ez-vcard/commit/15813248e5b833cefdc6fb53892a529ccf42a938#commitcomment-16689651

> Would it be possible to provide a way for users to assign their own jackson PrettyPrinter implementation to the JCardRawWriter?

It should be possible, but I wanted to make sure I got everything right before I made any changes to the api. The issue is that the `Indenter` interface and `indentArraysWith` method are both inside the DefaultPrettyPrinter class. So either we would be asking users to pass in a DefaultPrettyPrinter, or we'd need to implement something that makes the most common case (passing in a DefaultPrettyPrinter) more awkward.

And if a JsonGenerator is passed in (when using objectmapper), there's no way to get the internal state of the existing pretty printer, which means you wouldn't be able to match the previous indentation level.

I mean, it's probably doable, but it's pretty complex, so it might be better to bring this up over at https://github.com/FasterXML/jackson-core/issues first, see if we could get anything added to Jackson that would make it a bit cleaner.