### PR TITLE
multiple code improvements: squid:S1213, squid:S1854, squid:S1197, squid:UselessParenthesesCheck, squid:SwitchLastCaseIsDefaultCheck, squid:S1192

### DIFF
--- a/src/main/java/ezvcard/Ezvcard.java
+++ b/src/main/java/ezvcard/Ezvcard.java
@@ -138,6 +138,10 @@ public final class Ezvcard {
 		}
 	}
 
+	private Ezvcard() {
+		//hide
+	}
+
 	/**
 	 * <p>
 	 * Parses plain text vCards.
@@ -598,7 +602,4 @@ public final class Ezvcard {
 		return new ChainingJsonWriter(vcards);
 	}
 
-	private Ezvcard() {
-		//hide
-	}
 }

--- a/src/main/java/ezvcard/io/StreamReader.java
+++ b/src/main/java/ezvcard/io/StreamReader.java
@@ -57,7 +57,7 @@ public abstract class StreamReader implements Closeable {
 	 */
 	public List<VCard> readAll() throws IOException {
 		List<VCard> vcards = new ArrayList<VCard>();
-		VCard vcard = null;
+		VCard vcard;
 		while ((vcard = readNext()) != null) {
 			vcards.add(vcard);
 		}

--- a/src/main/java/ezvcard/io/html/HCardElement.java
+++ b/src/main/java/ezvcard/io/html/HCardElement.java
@@ -159,7 +159,7 @@ public class HCardElement {
 	 */
 	public void append(String text) {
 		boolean first = true;
-		String lines[] = text.split("\\r\\n|\\n|\\r");
+		String[] lines = text.split("\\r\\n|\\n|\\r");
 		for (String line : lines) {
 			if (!first) {
 				//replace newlines with "<br>" tags

--- a/src/main/java/ezvcard/io/json/JsonValue.java
+++ b/src/main/java/ezvcard/io/json/JsonValue.java
@@ -46,7 +46,7 @@ public class JsonValue {
 		this.value = value;
 		array = null;
 		object = null;
-		isNull = (value == null);
+		isNull = value == null;
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class JsonValue {
 		this.array = array;
 		value = null;
 		object = null;
-		isNull = (array == null);
+		isNull = array == null;
 	}
 
 	/**
@@ -68,7 +68,7 @@ public class JsonValue {
 		this.object = object;
 		value = null;
 		array = null;
-		isNull = (object == null);
+		isNull = object == null;
 	}
 
 	/**

--- a/src/main/java/ezvcard/io/scribe/BinaryPropertyScribe.java
+++ b/src/main/java/ezvcard/io/scribe/BinaryPropertyScribe.java
@@ -60,6 +60,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			return null;
 		case V4_0:
 			return VCardDataType.URI;
+		default:
+			break;
 		}
 		return null;
 	}
@@ -73,6 +75,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			case V3_0:
 			case V4_0:
 				return VCardDataType.URI;
+			default:
+				break;
 			}
 		}
 
@@ -83,6 +87,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 				return null;
 			case V4_0:
 				return VCardDataType.URI;
+			default:
+				break;
 			}
 		}
 
@@ -111,6 +117,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			case V4_0:
 				copy.setMediaType(contentType.getMediaType());
 				break;
+			default:
+				break;
 			}
 
 			return;
@@ -131,6 +139,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			case V4_0:
 				copy.setEncoding(null);
 				//don't null out TYPE, it could be set to "home", "work", etc
+				break;
+			default:
 				break;
 			}
 
@@ -183,7 +193,7 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			return _newInstance(uri.getData(), mediaType);
 		} catch (IllegalArgumentException e) {
 			//not a data URI
-			U mediaType = null;
+			U mediaType;
 			String type = element.attr("type");
 			if (type.length() > 0) {
 				mediaType = _mediaTypeFromMediaTypeParameter(type);
@@ -229,6 +239,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			return _newInstance(Base64.decodeBase64(value), contentType);
 		case V4_0:
 			return _newInstance(value, contentType);
+		default:
+			break;
 		}
 		return null;
 	}
@@ -258,7 +270,7 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 
 	protected abstract T _newInstance(String uri, U contentType);
 
-	protected abstract T _newInstance(byte data[], U contentType);
+	protected abstract T _newInstance(byte[] data, U contentType);
 
 	private U parseContentType(String value, VCardParameters parameters, VCardVersion version) {
 		switch (version) {
@@ -276,6 +288,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			if (mediaType != null) {
 				return _mediaTypeFromMediaTypeParameter(mediaType);
 			}
+			break;
+		default:
 			break;
 		}
 
@@ -315,6 +329,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 				//not a data URI
 			}
 			break;
+		default:
+			break;
 		}
 
 		return cannotUnmarshalValue(value, version, warnings, contentType);
@@ -330,7 +346,7 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 			return url;
 		}
 
-		byte data[] = property.getData();
+		byte[] data = property.getData();
 		if (data != null) {
 			switch (version) {
 			case V2_1:
@@ -340,6 +356,8 @@ public abstract class BinaryPropertyScribe<T extends BinaryProperty<U>, U extend
 				U contentType = property.getContentType();
 				String mediaType = (contentType == null || contentType.getMediaType() == null) ? "application/octet-stream" : contentType.getMediaType();
 				return new DataUri(mediaType, data).toString();
+			default:
+				break;
 			}
 		}
 

--- a/src/main/java/ezvcard/io/scribe/ClientPidMapScribe.java
+++ b/src/main/java/ezvcard/io/scribe/ClientPidMapScribe.java
@@ -40,6 +40,8 @@ import ezvcard.property.ClientPidMap;
  * @author Michael Angstadt
  */
 public class ClientPidMapScribe extends VCardPropertyScribe<ClientPidMap> {
+	private static final String SOURCEID = "sourceid";
+
 	public ClientPidMapScribe() {
 		super(ClientPidMap.class, "CLIENTPIDMAP");
 	}
@@ -69,24 +71,24 @@ public class ClientPidMapScribe extends VCardPropertyScribe<ClientPidMap> {
 	@Override
 	protected void _writeXml(ClientPidMap property, XCardElement parent) {
 		Integer pid = property.getPid();
-		parent.append("sourceid", (pid == null) ? "" : pid.toString());
+		parent.append(SOURCEID, (pid == null) ? "" : pid.toString());
 
 		parent.append(VCardDataType.URI, property.getUri());
 	}
 
 	@Override
 	protected ClientPidMap _parseXml(XCardElement element, VCardParameters parameters, List<String> warnings) {
-		String sourceid = element.first("sourceid");
+		String sourceid = element.first(SOURCEID);
 		String uri = element.first(VCardDataType.URI);
 
 		if (uri == null && sourceid == null) {
-			throw missingXmlElements(VCardDataType.URI.getName().toLowerCase(), "sourceid");
+			throw missingXmlElements(VCardDataType.URI.getName().toLowerCase(), SOURCEID);
 		}
 		if (uri == null) {
 			throw missingXmlElements(VCardDataType.URI);
 		}
 		if (sourceid == null) {
-			throw missingXmlElements("sourceid");
+			throw missingXmlElements(SOURCEID);
 		}
 
 		return parse(sourceid, uri);

--- a/src/main/java/ezvcard/io/scribe/ImppScribe.java
+++ b/src/main/java/ezvcard/io/scribe/ImppScribe.java
@@ -57,6 +57,43 @@ public class ImppScribe extends VCardPropertyScribe<Impp> {
 	public static final String XMPP = "xmpp";
 	public static final String YAHOO = "ymsgr";
 
+	/**
+	 * List of recognized IM protocols that can be parsed from an HTML link
+	 * (hCard).
+	 */
+	private static final List<HtmlLinkFormat> htmlLinkFormats;
+	static {
+		List<HtmlLinkFormat> list = new ArrayList<HtmlLinkFormat>();
+
+		//http://en.wikipedia.org/wiki/AOL_Instant_Messenger#URI_scheme
+		list.add(new HtmlLinkFormat(AIM, "(goim|addbuddy)\\?.*?\\bscreenname=(.*?)(&|$)", 2, "goim?screenname=%s"));
+
+		//http://en.wikipedia.org/wiki/Yahoo!_Messenger#URI_scheme
+		list.add(new HtmlLinkFormat(YAHOO, "(sendim|addfriend|sendfile|call)\\?(.*)", 2, "sendim?%s"));
+
+		//http://developer.skype.com/skype-uri/skype-uri-ref-api
+		list.add(new HtmlLinkFormat(SKYPE, "(.*?)(\\?|$)", 1, "%s"));
+
+		//http://www.tech-recipes.com/rx/1157/msn-messenger-msnim-hyperlink-command-codes/
+		list.add(new HtmlLinkFormat(MSN, "(chat|add|voice|video)\\?contact=(.*?)(&|$)", 2, "chat?contact=%s"));
+
+		//http://www.tech-recipes.com/rx/1157/msn-messenger-msnim-hyperlink-command-codes/
+		list.add(new HtmlLinkFormat(XMPP, "(.*?)(\\?|$)", 1, "%s?message"));
+
+		//http://forums.miranda-im.org/showthread.php?26589-Add-support-to-quot-icq-message-uin-12345-quot-web-links
+		list.add(new HtmlLinkFormat(ICQ, "message\\?uin=(\\d+)", 1, "message?uin=%s"));
+
+		//SIP: http://en.wikipedia.org/wiki/Session_Initiation_Protocol
+		//leave as-is
+		list.add(new HtmlLinkFormat(SIP));
+
+		//IRC: http://stackoverflow.com/questions/11970897/how-do-i-open-a-query-window-using-the-irc-uri-scheme
+		//IRC handles are not globally unique, so leave as-is
+		list.add(new HtmlLinkFormat(IRC));
+
+		htmlLinkFormats = Collections.unmodifiableList(list);
+	}
+
 	public ImppScribe() {
 		super(Impp.class, "IMPP");
 	}
@@ -140,43 +177,6 @@ public class ImppScribe extends VCardPropertyScribe<Impp> {
 		} catch (IllegalArgumentException e) {
 			throw new CannotParseException(15, value, e.getMessage());
 		}
-	}
-
-	/**
-	 * List of recognized IM protocols that can be parsed from an HTML link
-	 * (hCard).
-	 */
-	private static final List<HtmlLinkFormat> htmlLinkFormats;
-	static {
-		List<HtmlLinkFormat> list = new ArrayList<HtmlLinkFormat>();
-
-		//http://en.wikipedia.org/wiki/AOL_Instant_Messenger#URI_scheme
-		list.add(new HtmlLinkFormat(AIM, "(goim|addbuddy)\\?.*?\\bscreenname=(.*?)(&|$)", 2, "goim?screenname=%s"));
-
-		//http://en.wikipedia.org/wiki/Yahoo!_Messenger#URI_scheme
-		list.add(new HtmlLinkFormat(YAHOO, "(sendim|addfriend|sendfile|call)\\?(.*)", 2, "sendim?%s"));
-
-		//http://developer.skype.com/skype-uri/skype-uri-ref-api
-		list.add(new HtmlLinkFormat(SKYPE, "(.*?)(\\?|$)", 1, "%s"));
-
-		//http://www.tech-recipes.com/rx/1157/msn-messenger-msnim-hyperlink-command-codes/
-		list.add(new HtmlLinkFormat(MSN, "(chat|add|voice|video)\\?contact=(.*?)(&|$)", 2, "chat?contact=%s"));
-
-		//http://www.tech-recipes.com/rx/1157/msn-messenger-msnim-hyperlink-command-codes/
-		list.add(new HtmlLinkFormat(XMPP, "(.*?)(\\?|$)", 1, "%s?message"));
-
-		//http://forums.miranda-im.org/showthread.php?26589-Add-support-to-quot-icq-message-uin-12345-quot-web-links
-		list.add(new HtmlLinkFormat(ICQ, "message\\?uin=(\\d+)", 1, "message?uin=%s"));
-
-		//SIP: http://en.wikipedia.org/wiki/Session_Initiation_Protocol
-		//leave as-is
-		list.add(new HtmlLinkFormat(SIP));
-
-		//IRC: http://stackoverflow.com/questions/11970897/how-do-i-open-a-query-window-using-the-irc-uri-scheme
-		//IRC handles are not globally unique, so leave as-is
-		list.add(new HtmlLinkFormat(IRC));
-
-		htmlLinkFormats = Collections.unmodifiableList(list);
 	}
 
 	/**

--- a/src/main/java/ezvcard/io/scribe/VCardPropertyScribe.java
+++ b/src/main/java/ezvcard/io/scribe/VCardPropertyScribe.java
@@ -1147,6 +1147,8 @@ public abstract class VCardPropertyScribe<T extends VCardProperty> {
 				}
 			}
 			break;
+		default:
+			break;
 		}
 	}
 

--- a/src/main/java/ezvcard/io/text/VCardRawReader.java
+++ b/src/main/java/ezvcard/io/text/VCardRawReader.java
@@ -185,7 +185,7 @@ public class VCardRawReader implements Closeable {
 			}
 
 			if (isNewline(ch)) {
-				quotedPrintableLine = (inValue && prevChar == '=' && isQuotedPrintable(parameters));
+				quotedPrintableLine = inValue && prevChar == '=' && isQuotedPrintable(parameters);
 				if (quotedPrintableLine) {
 					/*
 					 * Remove the "=" character that some vCards put at the end

--- a/src/main/java/ezvcard/io/text/VCardRawWriter.java
+++ b/src/main/java/ezvcard/io/text/VCardRawWriter.java
@@ -335,7 +335,7 @@ public class VCardRawWriter implements Closeable, Flushable {
 		 * Determine if the property value must be encoded in quoted printable
 		 * encoding. If so, then determine what charset to use for the encoding.
 		 */
-		boolean useQuotedPrintable = (parameters.getEncoding() == Encoding.QUOTED_PRINTABLE);
+		boolean useQuotedPrintable = parameters.getEncoding() == Encoding.QUOTED_PRINTABLE;
 		Charset quotedPrintableCharset = null;
 		if (useQuotedPrintable) {
 			String charsetParam = parameters.getCharset();
@@ -422,7 +422,7 @@ public class VCardRawWriter implements Closeable, Flushable {
 			return false;
 		}
 		char first = string.charAt(0);
-		return (first == ' ' || first == '\t');
+		return first == ' ' || first == '\t';
 	}
 
 	/**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1854 - Dead stores should be removed.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava