### PR TITLE
Use a configuration object to provide the option to print parameters as

### DIFF
--- a/src/main/java/ezvcard/parameter/LowerCaseConfig.java
+++ b/src/main/java/ezvcard/parameter/LowerCaseConfig.java
@@ -1,0 +1,51 @@
+package ezvcard.parameter;
+
+public class LowerCaseConfig {
+	
+	/*
+	 Copyright (c) 2012-2016, Roberto Bertolino
+	 All rights reserved.
+
+	 Redistribution and use in source and binary forms, with or without
+	 modification, are permitted provided that the following conditions are met: 
+
+	 1. Redistributions of source code must retain the above copyright notice, this
+	 list of conditions and the following disclaimer. 
+	 2. Redistributions in binary form must reproduce the above copyright notice,
+	 this list of conditions and the following disclaimer in the documentation
+	 and/or other materials provided with the distribution. 
+
+	 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+	 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+	 ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+	 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	 The views and conclusions contained in the software and documentation are those
+	 of the authors and should not be interpreted as representing official policies, 
+	 either expressed or implied, of the FreeBSD Project.
+	 */
+	
+	/**
+	 * <p>
+	 * Defines a configuration object to provide the option to print parameters as lower case.
+	 * </p>
+	 */
+	
+	static private boolean lowerCase = false;
+	
+	public static synchronized void setLowerCase(boolean lowerCase) {
+		LowerCaseConfig.lowerCase = lowerCase;
+		
+	}
+	
+	public static synchronized boolean isLowerCase() {
+		return LowerCaseConfig.lowerCase;
+	}
+
+}

--- a/src/main/java/ezvcard/parameter/VCardParameter.java
+++ b/src/main/java/ezvcard/parameter/VCardParameter.java
@@ -56,11 +56,23 @@ public class VCardParameter {
 	/**
 	 * Creates a new parameter.
 	 * @param value the value
-	 * @param preserveCase true to preserve the case of the value, false convert
-	 * it to lower-case
+	 * @param preserveCase not used
+	 * 
+	 * The program uses a configuration static value instead to define lower case.
 	 */
 	protected VCardParameter(String value, boolean preserveCase) {
-		this.value = (value == null || preserveCase) ? value : value.toLowerCase();
+		String param = null;
+		
+		if (value != null) {			
+			param = value;
+			if (LowerCaseConfig.isLowerCase()) {
+				param = value.toLowerCase();
+			} else {
+				param = value;
+			}			
+		}
+		
+		this.value = param;
 	}
 
 	/**

--- a/src/test/java/ezvcard/parameter/VCardParameterTest.java
+++ b/src/test/java/ezvcard/parameter/VCardParameterTest.java
@@ -66,6 +66,7 @@ public class VCardParameterTest {
 
 	@Test
 	public void value_to_lowercase() {
+		LowerCaseConfig.setLowerCase(true);
 		VCardParameterImpl three = new VCardParameterImpl("THREE");
 		assertEquals("three", three.getValue());
 	}


### PR DESCRIPTION
Suggestion to use a configuration object to define how parameters are printed.