### PR TITLE
Fix test on Windows - issue with new line character

### DIFF
--- a/src/test/java/ezvcard/io/text/SampleVCardsTest.java
+++ b/src/test/java/ezvcard/io/text/SampleVCardsTest.java
@@ -1174,7 +1174,7 @@ public class SampleVCardsTest {
 		.noMore();
 		
 		asserter.simpleProperty(Note.class)
-			.value("note line 1\nnote line 2\nCustomField: field value")
+			.value("note line 1" + NEWLINE + "note line 2" + NEWLINE + "CustomField: field value")
 		.noMore();
 		
 		asserter.rawProperty("X-PHONETIC-FIRST-NAME")


### PR DESCRIPTION
Fix test on Windows platform by using `NEWLINE` instead of `\n`.