### PR TITLE
Doc - Method addPrefix(String) no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VCard vcard = new VCard();
 StructuredName n = new StructuredName();
 n.setFamily("Doe");
 n.setGiven("Jonathan");
-n.addPrefix("Mr");
+n.getPrefixes().add("Mr");
 vcard.setStructuredName(n);
 
 vcard.setFormattedName("John Doe");


### PR DESCRIPTION
Method `n.addPrefix(String)` replaced by `n.getPrefixes().add(String)`.