### PR TITLE
Allow extending contact mechanism

### DIFF
--- a/src/main/java/ezvcard/parameter/AddressType.java
+++ b/src/main/java/ezvcard/parameter/AddressType.java
@@ -68,7 +68,7 @@ public class AddressType extends VCardParameter {
 	@SupportedVersions({ V2_1, V3_0 })
 	public static final AddressType PREF = new AddressType("pref");
 
-	private AddressType(String value) {
+	AddressType(String value) {
 		super(value);
 	}
 

--- a/src/main/java/ezvcard/parameter/EmailType.java
+++ b/src/main/java/ezvcard/parameter/EmailType.java
@@ -93,7 +93,7 @@ public class EmailType extends VCardParameter {
 	@SupportedVersions(V4_0)
 	public static final EmailType WORK = new EmailType("work");
 
-	private EmailType(String value) {
+	EmailType(String value) {
 		super(value);
 	}
 

--- a/src/main/java/ezvcard/parameter/ImppType.java
+++ b/src/main/java/ezvcard/parameter/ImppType.java
@@ -50,7 +50,7 @@ public class ImppType extends VCardParameter {
 	public static final ImppType MOBILE = new ImppType("mobile");
 	public static final ImppType PREF = new ImppType("pref");
 
-	private ImppType(String value) {
+	ImppType(String value) {
 		super(value);
 	}
 

--- a/src/main/java/ezvcard/parameter/TelephoneType.java
+++ b/src/main/java/ezvcard/parameter/TelephoneType.java
@@ -89,7 +89,7 @@ public class TelephoneType extends VCardParameter {
 
 	public static final TelephoneType WORK = new TelephoneType("work");
 
-	private TelephoneType(String value) {
+	TelephoneType(String value) {
 		super(value);
 	}
 


### PR DESCRIPTION
Now you can't convert to and from contact managers that allow custom labels (in addition to home, work, etc) for contact methods. If we allow extending type classes, like EmailType, there will be a way to construct these for the custom types.