### PR TITLE
Jigsaw modules support without dropping support for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,28 @@
 					</archive>
 				</configuration>
 			</plugin>
+
+			<!-- Support for Java 9+ Module System(Jigsaw) -->
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.Beta2</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<configuration>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+							<module>
+								<moduleInfoFile>src/main/moditect/module-info.java</moduleInfoFile>
+							</module>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.4.0</version>
+				<version>3.5.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/src/main/moditect/module-info.java
+++ b/src/main/moditect/module-info.java
@@ -1,0 +1,21 @@
+module ezvcard {
+  requires vinnie;
+  requires java.xml;
+  requires freemarker;
+  requires org.jsoup;
+  requires com.fasterxml.jackson.core;
+  requires com.fasterxml.jackson.databind;
+  exports ezvcard;
+  exports ezvcard.io;
+  exports ezvcard.io.chain;
+  exports ezvcard.io.html;
+  exports ezvcard.io.json;
+  exports ezvcard.io.scribe;
+  exports ezvcard.io.text;
+  exports ezvcard.io.xml;
+  exports ezvcard.parameter;
+  exports ezvcard.property;
+  exports ezvcard.util;
+  exports ezvcard.util.org.apache.commons.codec;
+  exports ezvcard.util.org.apache.commons.codec.binary;
+}

--- a/src/main/moditect/module-info.java
+++ b/src/main/moditect/module-info.java
@@ -1,10 +1,9 @@
-module ezvcard {
+open module ezvcard {
   requires vinnie;
   requires java.xml;
   requires freemarker;
   requires org.jsoup;
   requires com.fasterxml.jackson.core;
-  requires com.fasterxml.jackson.databind;
   exports ezvcard;
   exports ezvcard.io;
   exports ezvcard.io.chain;


### PR DESCRIPTION
Hello,
I've added support for Java 9+ modules using the moditect plugin. This doesn't require dropping support for Java 8. I've done some testing and everything looks to be working