### PR TITLE
Update to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 	</scm>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>
@@ -110,16 +110,10 @@
 			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency> <!-- For testing XML 1.1 -->
-			<groupId>xalan</groupId>
-			<artifactId>xalan</artifactId>
-			<version>2.7.2</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 		    <groupId>nl.jqno.equalsverifier</groupId>
 		    <artifactId>equalsverifier</artifactId>
-		    <version>1.7.6</version>
+		    <version>3.14.2</version>
 		    <scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -146,7 +140,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.4.0</version>
+				<version>5.1.9</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
@@ -170,7 +164,7 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.11.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<source>${java.version}</source>
@@ -313,7 +307,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.5.201505241946</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>
@@ -332,6 +326,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/**
+ * A library that reads and writes vCards, supporting all versions of the vCard standard (2.1, 3.0,
+ * and 4.0) as well as xCard (XML-encoded vCards), hCard (HTML-encoded vCards), and jCard
+ * (JSON-encoded vCards).
+ */
+module com.googlecode.ezvcard {
+	exports ezvcard;
+	exports ezvcard.io;
+	exports ezvcard.io.chain;
+	exports ezvcard.io.html;
+	exports ezvcard.io.json;
+	exports ezvcard.io.scribe;
+	exports ezvcard.io.text;
+	exports ezvcard.io.xml;
+	
+	exports ezvcard.parameter;
+	exports ezvcard.property;
+	exports ezvcard.util;
+	
+	opens ezvcard.io.html to freemarker;
+	opens ezvcard.io.scribe to freemarker;
+	opens ezvcard.parameter to freemarker;
+	opens ezvcard.property to freemarker;
+	opens ezvcard.util to freemarker;
+	
+	opens ezvcard.io.json to com.fasterxml.jackson.databind;
+	
+	requires vinnie;
+	requires com.fasterxml.jackson.databind;
+	requires org.jsoup;
+	requires java.xml;
+	requires freemarker;
+}

--- a/src/test/java/ezvcard/io/xml/XCardDocumentTest.java
+++ b/src/test/java/ezvcard/io/xml/XCardDocumentTest.java
@@ -646,23 +646,13 @@ public class XCardDocumentTest {
 	}
 
 	@Test
-	public void write_xmlVerison_1_1() throws Throwable {
-		VCard vcard = new VCard();
-		XCardDocument xcard = new XCardDocument();
-		xcard.addVCard(vcard);
-
-		String xml = xcard.write(null, "1.1");
-		assertTrue(xml.matches("(?i)<\\?xml.*?version=\"1.1\".*?\\?>.*"));
-	}
-
-	@Test
 	public void write_xmlVerison_invalid() throws Throwable {
 		VCard vcard = new VCard();
 		XCardDocument xcard = new XCardDocument();
 		xcard.addVCard(vcard);
 
 		String xml = xcard.write(null, "10.17");
-		assertTrue(xml.matches("(?i)<\\?xml.*?version=\"1.0\".*?\\?>.*"));
+		assertTrue(xml, xml.matches("(?i)<\\?xml.*?version=\"1.0\".*?\\?>.*"));
 	}
 
 	@Test

--- a/src/test/java/ezvcard/io/xml/XCardWriterTest.java
+++ b/src/test/java/ezvcard/io/xml/XCardWriterTest.java
@@ -635,30 +635,6 @@ public class XCardWriterTest {
 	}
 
 	@Test
-	public void write_xmlVersion_1_1() throws Exception {
-		StringWriter sw = new StringWriter();
-		XCardWriter writer = new XCardWriter(sw, null, "1.1");
-		VCard vcard = new VCard();
-		writer.write(vcard);
-		writer.close();
-
-		String xml = sw.toString();
-		assertTrue(xml.matches("(?i)<\\?xml.*?version=\"1.1\".*?\\?>.*"));
-	}
-
-	@Test
-	public void write_xmlVersion_invalid() throws Exception {
-		StringWriter sw = new StringWriter();
-		XCardWriter writer = new XCardWriter(sw, null, "10.17");
-		VCard vcard = new VCard();
-		writer.write(vcard);
-		writer.close();
-
-		String xml = sw.toString();
-		assertTrue(xml.matches("(?i)<\\?xml.*?version=\"1.0\".*?\\?>.*"));
-	}
-
-	@Test
 	public void write_utf8() throws Exception {
 		Path file = tempFolder.newFile().toPath();
 		XCardWriter writer = new XCardWriter(file);


### PR DESCRIPTION
Java 8 is now really out of date and consuming the ez-vcard dependency is not possible from a modular Java 11 project.

* Added module-info to be able to consume ezvcard from a modular Java 11 project.
* Updated dependencies required to be able to compile with Java 11.
* Removed xalan and tests dependent on xalan since it imports a dependency (xml-apis) that conflicts with the Java 11 module path.
* The `opens` statements are just enough to make the tests run.
* All packages are exported, maybe the API could be further restricted?