### PR TITLE
Bugfix generating hcard geo

### DIFF
--- a/src/main/java/ezvcard/io/html/HCardPage.java
+++ b/src/main/java/ezvcard/io/html/HCardPage.java
@@ -1,5 +1,7 @@
 package ezvcard.io.html;
 
+// import androidx.annotation.RequiresApi;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -26,6 +28,7 @@ import ezvcard.parameter.ImageType;
 import ezvcard.property.Photo;
 import ezvcard.util.DataUri;
 import ezvcard.util.VCardDateFormat;
+import ezvcard.util.VCardFloatFormatter;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -82,6 +85,10 @@ import freemarker.template.TemplateException;
  * @see <a
  * href="http://microformats.org/wiki/hcard">http://microformats.org/wiki/hcard</a>
  */
+@SuppressWarnings(
+		{// "NewApi", // lib is for android-api-21. Some Path/Datetime require android-api-26 or desugar lib
+				"Unused"}) // this is a lib
+// @RequiresApi(26)
 public class HCardPage {
 	private final Template template;
 	private final List<VCard> vcards = new ArrayList<>();
@@ -219,5 +226,8 @@ public class HCardPage {
 		public String format(ZoneOffset offset) {
 			return VCardDateFormat.BASIC.format(offset);
 		}
-	}
+
+		public String format(Double d) {
+			return new VCardFloatFormatter().format(d);
+		}	}
 }

--- a/src/main/java/ezvcard/io/html/HCardPage.java
+++ b/src/main/java/ezvcard/io/html/HCardPage.java
@@ -1,7 +1,5 @@
 package ezvcard.io.html;
 
-// import androidx.annotation.RequiresApi;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -85,10 +83,6 @@ import freemarker.template.TemplateException;
  * @see <a
  * href="http://microformats.org/wiki/hcard">http://microformats.org/wiki/hcard</a>
  */
-@SuppressWarnings(
-		{// "NewApi", // lib is for android-api-21. Some Path/Datetime require android-api-26 or desugar lib
-				"Unused"}) // this is a lib
-// @RequiresApi(26)
 public class HCardPage {
 	private final Template template;
 	private final List<VCard> vcards = new ArrayList<>();

--- a/src/main/resources/ezvcard/io/html/hcard-template.html
+++ b/src/main/resources/ezvcard/io/html/hcard-template.html
@@ -379,8 +379,8 @@
 					<#if v.geo?? && v.geo.latitude?? && v.geo.longitude??>
 						<span class="l">Geo: </span>
 						<span class="geo">
-							<span class="latitude">${v.geo.latitude?string("0.######")}</span>,
-							<span class="longitude">${v.geo.longitude?string("0.######")}</span>
+							<span class="latitude">${utils.format(v.geo.latitude)}</span>,
+							<span class="longitude">${utils.format(v.geo.longitude)}</span>
 						</span>
 						<br />
 					</#if>

--- a/src/test/java/ezvcard/io/html/HCardPageTest.java
+++ b/src/test/java/ezvcard/io/html/HCardPageTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -242,7 +243,9 @@ public class HCardPageTest {
 		String html = template.write();
 
 		//write to file for manual inspection
-		try (Writer writer = Files.newBufferedWriter(Paths.get("target", "vcard.html"))) {
+		Path file = Paths.get("target", "vcard.html");
+		Files.createDirectories(file.getParent());
+		try (Writer writer = Files.newBufferedWriter(file)) {
 			writer.write(html);
 		}
 


### PR DESCRIPTION
Fix: Old implementation "generating hcard-geo" info used current locale to format decimal latitude/logitude.

If current locale was de-DE decimal latitude/logitude where written as "12,34" instead of "12.34".
