### PR TITLE
Save up some memory when defensive-copying warnings

### DIFF
--- a/src/main/java/ezvcard/io/StreamReader.java
+++ b/src/main/java/ezvcard/io/StreamReader.java
@@ -3,6 +3,7 @@ package ezvcard.io;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -151,6 +152,10 @@ public abstract class StreamReader implements Closeable {
 	 * @return the warnings or empty list if there were no warnings
 	 */
 	public List<ParseWarning> getWarnings() {
-		return new ArrayList<>(warnings);
+		switch (warnings.size()) {
+			case 0: return Collections.emptyList();
+			case 1: return Collections.singletonList(warnings.get(0));
+			default: return new ArrayList<>(warnings);
+		}
 	}
 }


### PR DESCRIPTION
We've never said that the returned list is mutable, right?

Now returning an empty warnings list (which is very common) has zero allocation cost.

Inspiration source: https://github.com/JetBrains/kotlin/blob/62a0b634f1b3b0a9133dddd37c83a198eabc5022/libraries/stdlib/common/src/generated/_Collections.kt#L1344-L1348